### PR TITLE
Improve Compilation Error (CE) user feedback in CXX compilers

### DIFF
--- a/std/compilers.py
+++ b/std/compilers.py
@@ -282,7 +282,11 @@ class Compiler_GenericC(Compiler):
         if util.file_exists('program.exe'):
             return True
         else:
-            util.write_file('compilation1.txt', "Unreported error. ")
+            if util.file_size('compilation1.txt') == 0:
+                if util.file_size('compilation2.txt') == 0:
+                    util.write_file('compilation1.txt', "Unreported error. ")
+                else:
+                    util.move_file('compilation2.txt', 'compilation1.txt')
             util.del_file('program.exe')
             return False
 
@@ -382,7 +386,11 @@ class Compiler_GenericCXX(Compiler):
         if util.file_exists('program.exe'):
             return True
         else:
-            util.write_file('compilation1.txt', 'Unreported error. ')
+            if util.file_size('compilation1.txt') == 0:
+                if util.file_size('compilation2.txt') == 0:
+                    util.write_file('compilation1.txt', "Unreported error. ")
+                else:
+                    util.move_file('compilation2.txt', 'compilation1.txt')
             util.del_file('program.exe')
             return False
 
@@ -430,7 +438,11 @@ class Compiler_GenericCXX(Compiler):
         if util.file_exists('program.exe'):
             return True
         else:
-            util.write_file('compilation1.txt', "Unreported error. ")
+            if util.file_size('compilation1.txt') == 0:
+                if util.file_size('compilation2.txt') == 0:
+                    util.write_file('compilation1.txt', "Unreported error. ")
+                else:
+                    util.move_file('compilation2.txt', 'compilation1.txt')
             util.del_file('program.exe')
             return False
 


### PR DESCRIPTION
This pull request aims to close #3 by overwriting the compilation1.txt file with the second one in the event it finds the first one is empty and the second one is not.

Locally, this makes the CE give the following result: 

```
/usr/bin/ld: /tmp/ccef6Giv.o: in function `main':
program.cc:(.text.startup+0x29e): undefined reference to `punt_verd(int, std::queue<int, std::deque<int, std::allocator<int> > >&)'
collect2: error: ld returned 1 exit status
```

This pull request however assumes that the website reads only the first file for all compilers.